### PR TITLE
fix(test) run setup/teardown only if required

### DIFF
--- a/spec/myplugin/01-access_spec.lua
+++ b/spec/myplugin/01-access_spec.lua
@@ -6,7 +6,7 @@ for _, strategy in helpers.each_strategy() do
   describe("Demo-Plugin: myplugin (access) [#" .. strategy .. "]", function()
     local client
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local route1 = bp.routes:insert({
@@ -30,7 +30,7 @@ for _, strategy in helpers.each_strategy() do
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong(nil, true)
     end)
 


### PR DESCRIPTION
regular setup/teardown always run, the lazy_setup/lazy_teardown
only run when actually used.
So now when running tests with '--tags=postgres' the (very slow)
Cassandra setup/teardown no longer run, speeding up overall tests.