### PR TITLE
Fix test helpers for Kong 0.15.0/1.0.0 and later

### DIFF
--- a/spec/myplugin/01-access_spec.lua
+++ b/spec/myplugin/01-access_spec.lua
@@ -7,14 +7,14 @@ for _, strategy in helpers.each_strategy() do
     local client
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, nil, { "myplugin" })
 
       local route1 = bp.routes:insert({
         hosts = { "test1.com" },
       })
       bp.plugins:insert {
         name = "myplugin",
-        route_id = route1.id,
+        route = { id = route1.id },
         config = {},
       }
 


### PR DESCRIPTION
This takes the work of @sfhardman and adds a version check to keep it compatible with older versions of Kong.