### PR TITLE
chore(windows) add .gitattributes for line-endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
On Windows systems line endings need to be preserved to be able to
run from unix based VMs and shells