### PR TITLE
chore(*) update for Kong 3.x and Pongo 2.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,11 @@ jobs:
       fail-fast: false
       matrix:
         kongVersion:
-        - "2.7.x"
         - "2.8.x"
+        - "3.0.x"
         - "nightly"
-        - "2.7.2.x"
         - "2.8.1.x"
+        - "3.0.0.x"
         - "nightly-ee"
 
     steps:

--- a/.pongo/pongorc
+++ b/.pongo/pongorc
@@ -1,3 +1,3 @@
 --postgres
---cassandra
+--no-cassandra
 

--- a/spec/myplugin/02-integration_spec.lua
+++ b/spec/myplugin/02-integration_spec.lua
@@ -4,7 +4,7 @@ local helpers = require "spec.helpers"
 local PLUGIN_NAME = "myplugin"
 
 
-for _, strategy in helpers.all_strategies() do
+for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
   describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "]", function()
     local client
 
@@ -86,4 +86,5 @@ for _, strategy in helpers.all_strategies() do
     end)
 
   end)
-end
+
+end end


### PR DESCRIPTION
Pongo 2 will no longer start Cassandra by default, since Cassandra is deprecated in Kong 3.

see https://github.com/Kong/kong-pongo/pull/324