### PR TITLE
test: try update kong-pongo-action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
       with:
         password: ${{ secrets.PULP_PASSWORD }}
 
-    - uses: Kong/kong-pongo-action@v1
+    - uses: Kong/kong-pongo-action@fix/dev-ee-build
       with:
         pongo_version: master
         kong_version: ${{ matrix.kongVersion }}


### PR DESCRIPTION
_(TL;DR: bug in `kong-pongo-action`, see Kong/kong-pongo-action#2 for the fix)_

Looks like the build is failing due to 7d2759493cfb1a73ee01553862210ca4b938b9d3, which changed the matrix from `nightly-ee` to `dev-ee`. However, no corresponding change was made on line [128](https://github.com/Kong/kong-pongo-action/blob/adeae9f9dbdb836529dab3658326fcdaa837bdd2/action.yaml#L128) in `Kong/kong-pongo-action/action.yaml`. This is the current state of that line (as of [`adeae9f`](https://github.com/Kong/kong-pongo-action/tree/adeae9f9dbdb836529dab3658326fcdaa837bdd2)):

```
        if [ "${{ inputs.kong_version }}" == "nightly-ee" ]; then
```

That condition determines whether or not the `DOCKER_USERNAME` and `DOCKER_PASSWORD` are set to pull private images:

```
        if [ "${{ inputs.kong_version }}" == "nightly-ee" ]; then
          echo "DOCKER_USERNAME=${{ inputs.enterprise_nightly_docker_username }}" >> $GITHUB_ENV
          echo "DOCKER_PASSWORD=${{ inputs.enterprise_nightly_docker_password }}" >> $GITHUB_ENV
          echo Exported DOCKER_USERNAME and DOCKER_PASSWORD as global environment variables
        fi

```

It is evident from [this](https://github.com/Kong/kong-plugin/actions/runs/4258088463/jobs/7408938639#step:4:517) GHA step that those lines do not get run. We should see `Exported DOCKER_USERNAME and DOCKER_PASSWORD as global environment variables` immediately before the line`⏷Run pongo up`, but as you can see from the screenshot, it is absent:

![image](https://user-images.githubusercontent.com/3081566/221304315-044bc9df-c8e7-46ba-b5ac-3b1b7fdf9169.png)


Additionally, [this](https://github.com/Kong/kong-plugin/actions/runs/4258088463/jobs/7408938639#step:4:565) section shows that the environments variables for when `pongo build` is run is missing the `DOCKER_USERNAME` and `DOCKER_PASSWORD`:

![image](https://user-images.githubusercontent.com/3081566/221303669-aee037b0-93a4-4f68-8a9d-97fd25435cb8.png)

