### PR TITLE
Revert "Update timeout for .github/workflows/lint.yml (#44)"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,6 @@ on:
 
 jobs:
   luacheck:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ on:
 
 jobs:
   test:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
These settings are Kong specific, and will fail for users cloning the repo (which is the primary use case of this repo)