### PR TITLE
fix(ci): add write permission to license-checker workflow

### DIFF
--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -1,6 +1,9 @@
 name: "Apply EE License and Copyright"
 on: [create]
 
+permissions:
+  contents: write
+
 env:
   SENDER: ${{ github.event.sender.login }}
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The missing contents:write permission was causing the license checker cleanup job to fail. This commit adds the missing permission.