### PR TITLE
chore(luacov): disable the test coverage by default

### DIFF
--- a/.busted
+++ b/.busted
@@ -1,7 +1,7 @@
 return {
   default = {
     verbose = true,
-    coverage = true,
+    coverage = false,
     output = "gtest",
   },
 }


### PR DESCRIPTION
We found that enabling test coverage has a significant impact on the execution speed of test cases, so this option is disabled by default. If users need it, they can explicitly enable it using the `--coverage` option.

```
$ time bin/busted -c -v -o gtest /kong-plugin/spec/myplugin/10-integration_spec.lua                                                                                   
2025/12/04 02:55:32 [warn] 130#0: LMDB database is corrupted or incompatible, removing                                                                                                                           
[==========] Running tests from scanned files.                                                                                                                                                                   
[----------] Global test environment setup.                                                                                                                                                                      
[----------] Running tests from /kong-plugin/spec/myplugin/10-integration_spec.lua                                                                                                                               
[ RUN      ] /kong-plugin/spec/myplugin/10-integration_spec.lua:55: myplugin: (access) [#postgres] request gets a 'hello-world' header                                                                           
[       OK ] /kong-plugin/spec/myplugin/10-integration_spec.lua:55: myplugin: (access) [#postgres] request gets a 'hello-world' header (45.88 ms)                                                                
[ RUN      ] /kong-plugin/spec/myplugin/10-integration_spec.lua:73: myplugin: (access) [#postgres] response gets a 'bye-world' header                                                                            
[       OK ] /kong-plugin/spec/myplugin/10-integration_spec.lua:73: myplugin: (access) [#postgres] response gets a 'bye-world' header (8.16 ms)                                                                  
[ RUN      ] /kong-plugin/spec/myplugin/10-integration_spec.lua:55: myplugin: (access) [#off] request gets a 'hello-world' header                                                                                
[       OK ] /kong-plugin/spec/myplugin/10-integration_spec.lua:55: myplugin: (access) [#off] request gets a 'hello-world' header (433.33 ms)                                                                    
[ RUN      ] /kong-plugin/spec/myplugin/10-integration_spec.lua:73: myplugin: (access) [#off] response gets a 'bye-world' header                                                                                 
[       OK ] /kong-plugin/spec/myplugin/10-integration_spec.lua:73: myplugin: (access) [#off] response gets a 'bye-world' header (7.73 ms)                                                                       
[----------] 4 tests from /kong-plugin/spec/myplugin/10-integration_spec.lua (359923.00 ms total)                                                                                                                
                                                                                                                                                                                                                 
[----------] Global test environment teardown.                                                                                                                                                                   
[==========] 4 tests from 1 test file ran. (359943.40 ms total)                                                                                                                                                  
[  PASSED  ] 4 tests.

real    6m0.958s
user    5m50.077s
sys     0m2.850s
$
$ time bin/busted --no-coverage -v -o gtest /kong-plugin/spec/myplugin/10-integration_spec.lua
2025/12/04 03:01:53 [warn] 1320#0: LMDB database is corrupted or incompatible, removing
[==========] Running tests from scanned files.
[----------] Global test environment setup.
[----------] Running tests from /kong-plugin/spec/myplugin/10-integration_spec.lua
[ RUN      ] /kong-plugin/spec/myplugin/10-integration_spec.lua:55: myplugin: (access) [#postgres] request gets a 'hello-world' header
[       OK ] /kong-plugin/spec/myplugin/10-integration_spec.lua:55: myplugin: (access) [#postgres] request gets a 'hello-world' header (56.03 ms)
[ RUN      ] /kong-plugin/spec/myplugin/10-integration_spec.lua:73: myplugin: (access) [#postgres] response gets a 'bye-world' header
[       OK ] /kong-plugin/spec/myplugin/10-integration_spec.lua:73: myplugin: (access) [#postgres] response gets a 'bye-world' header (3.02 ms)
[ RUN      ] /kong-plugin/spec/myplugin/10-integration_spec.lua:55: myplugin: (access) [#off] request gets a 'hello-world' header
[       OK ] /kong-plugin/spec/myplugin/10-integration_spec.lua:55: myplugin: (access) [#off] request gets a 'hello-world' header (231.34 ms)
[ RUN      ] /kong-plugin/spec/myplugin/10-integration_spec.lua:73: myplugin: (access) [#off] response gets a 'bye-world' header
[       OK ] /kong-plugin/spec/myplugin/10-integration_spec.lua:73: myplugin: (access) [#off] response gets a 'bye-world' header (2.02 ms)
[----------] 4 tests from /kong-plugin/spec/myplugin/10-integration_spec.lua (15368.91 ms total)

[----------] Global test environment teardown.
[==========] 4 tests from 1 test file ran. (15370.02 ms total)
[  PASSED  ] 4 tests.

real    0m16.256s
user    0m9.866s
sys     0m2.065s
$
```